### PR TITLE
Flowplayer should use the first mp4 (or maybe m4v) source.

### DIFF
--- a/videos/media/videos/scripts/videos.js
+++ b/videos/media/videos/scripts/videos.js
@@ -18,11 +18,23 @@ function initVideo(content) {
     content.find('.video-content').each(function() {
         var videocontent = $(this);
         var video = videocontent.find('video');
+        var videoLink = video.find('a:first');
         var chapters = videocontent.find('.chapters');
+        var sources = video.find('source');
+
+        // Update the anchor href with the mp4 or m4v source
+        sources.each(function() {
+            var src = $(this).attr('src');
+            var ext = src.split('.').pop();
+            if(ext === 'mp4' || ext === 'm4v') {
+                videoLink.attr('href', src);
+                return;
+            }
+        });
 
         // Add flowplayer
         if ('application/x-shockwave-flash' in navigator.mimeTypes) {
-            player = video.find('a:first').attr({'class': 'video'}).replaceAll(video).flowplayer(
+            player = videoLink.attr({'class': 'video'}).replaceAll(video).flowplayer(
                 fpconfig.path, fpconfig).flowplayer(0);
             if (player) {
                 player.awsrtmp();

--- a/videos/templates/videos/_video.html
+++ b/videos/templates/videos/_video.html
@@ -11,7 +11,7 @@
 
         <video controls {% if video.preview %}poster="{{ video.preview.url }}"{% endif %}>
             {% for source in sources %}
-                <source src="{{ source.file.url }}"  type="{{ source.type }}">
+                <source src="{{ source.file.url }}" type="{{ source.type }}">
             {% endfor %}
 
             {% with source=sources|first %}


### PR DESCRIPTION
Currently Flowplayer uses the `href` of the `<a>` tag inside the video: 

https://github.com/incuna/incuna-videos/blob/master/videos/media/videos/scripts/videos.js#L20-L24

Since this may not be an appropriate format for flowplayer the script should look for a `source` that has an appropriate `src` (or `type`) attribute and only use frlowplayer if one is found and set the `href` of the `<a>` to the correct `src`.
